### PR TITLE
feat: add support for creating GitHub Actions secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 | Name | Type |
 |------|------|
 | [github_actions_organization_secret.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_organization_secret) | resource |
+| [github_actions_secret.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_branch_default.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_default) | resource |
 | [github_branch_protection.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
 | [github_branch_protection.versions](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
@@ -35,6 +36,6 @@
 | <a name="input_billing_email"></a> [billing\_email](#input\_billing\_email) | n/a | `string` | n/a | yes |
 | <a name="input_members"></a> [members](#input\_members) | n/a | `map(string)` | n/a | yes |
 | <a name="input_organization_secrets"></a> [organization\_secrets](#input\_organization\_secrets) | n/a | `map(string)` | n/a | yes |
-| <a name="input_repositories"></a> [repositories](#input\_repositories) | n/a | <pre>map(object({<br>    visibility                      = optional(string, "private")<br>    auto_init                       = optional(bool, true)<br>    archived                        = optional(bool, false)<br>    description                     = optional(string, "")<br>    homepage_url                    = optional(string, "")<br>    is_template                     = optional(bool, false)<br>    teams                           = optional(list(string))<br>    required_status_checks_contexts = optional(list(string))<br>    pages = optional(object({<br>      branch = optional(string)<br>      path   = optional(string)<br>    }))<br>    template = optional(object({<br>      owner      = optional(string)<br>      repository = optional(string)<br>    }))<br>  }))</pre> | n/a | yes |
+| <a name="input_repositories"></a> [repositories](#input\_repositories) | n/a | <pre>map(object({<br>    visibility                      = optional(string, "private")<br>    auto_init                       = optional(bool, true)<br>    archived                        = optional(bool, false)<br>    description                     = optional(string, "")<br>    homepage_url                    = optional(string, "")<br>    is_template                     = optional(bool, false)<br>    teams                           = optional(list(string))<br>    required_status_checks_contexts = optional(list(string))<br>    action_secrets                  = optional(map(string), {})<br>    pages = optional(object({<br>      branch = optional(string)<br>      path   = optional(string)<br>    }))<br>    template = optional(object({<br>      owner      = optional(string)<br>      repository = optional(string)<br>    }))<br>  }))</pre> | n/a | yes |
 | <a name="input_teams"></a> [teams](#input\_teams) | n/a | <pre>map(object({<br>    members = optional(list(string))<br>  }))</pre> | n/a | yes |
 <!-- END_TF_DOCS -->

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,7 @@ variable "repositories" {
     is_template                     = optional(bool, false)
     teams                           = optional(list(string))
     required_status_checks_contexts = optional(list(string))
+    action_secrets                  = optional(map(string), {})
     pages = optional(object({
       branch = optional(string)
       path   = optional(string)


### PR DESCRIPTION
This commit adds support for creating GitHub Actions secrets using the `github_actions_secret` resource. The secrets are defined in the `repositories` variable as a map of maps, where each repository can have a map of secrets. The secrets are flattened into a list of objects and then transformed into a map for use in the `github_actions_secret` resource.

The `github_actions_secret` resource is created for each secret in each repository. The secret name is converted to lowercase to comply with GitHub's requirements.